### PR TITLE
fixed click zone on map for older browsers (eg: ff38)

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -64,7 +64,7 @@ function colorizeMap(data) {
 function initMap(data) {
   colorizeMap(data);
   var segments = document.querySelectorAll('svg g *[id]');
-  segments.forEach(function(segment) {
+  [].forEach.call(segments, function(segment) {
     segment.addEventListener('click', displayInfos);
     segment.addEventListener('mouseenter', focusSegment);
     segment.addEventListener('mouseout', unfocusSegment);


### PR DESCRIPTION
Older browsers have the click on a region that is not intercepted.
`segments` is a `NodeList`, it does not have a `forEach` method